### PR TITLE
Removing scroll from index

### DIFF
--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -67,7 +67,6 @@
     if (e.keyCode == 39) {carouselControlNext.click()}
   });
 
-
   document.addEventListener("wheel", (e) => {
     if(e.deltaX > 40) {
       carouselControlNext.click()
@@ -75,6 +74,10 @@
       carouselControlPrev.click()
     }
   })
+
+  const navHeight = document.querySelector('.navbar').clientHeight;
+  const carousel = document.querySelector('.carousel-inner');
+  carousel.setAttribute("style",`max-height: calc(100vh - ${navHeight}px)`);
 </script>
 
 <style>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -12,14 +12,6 @@
   </a>
   <!--/.Controls-->
 
-  <!--Indicators-->
-  <ol class="carousel-indicators">
-    <li data-target="#carouselExampleControls" data-slide-to="0" class="active"></li>
-    <li data-target="#carouselExampleControls" data-slide-to="1"></li>
-    <li data-target="#carouselExampleControls" data-slide-to="2"></li>
-  </ol>
-  <!--/.Indicators-->
-
   <!--Slides-->
   <div class="carousel-inner" role="listbox">
     <% counter = 0 %>
@@ -88,4 +80,3 @@
 <style>
   body { overscroll-behavior-x: none; }
 </style>
-


### PR DESCRIPTION
Added javascript styling to carousel element such that height will never overflow and cause a scroll no matter the client browser. Javascript required as navbar changes height dependant on screen resolutions.