### PR TITLE
Focus on carousel controls on load for smaller screen sizes

### DIFF
--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -75,7 +75,6 @@
     if (e.keyCode == 39) {carouselControlNext.click()}
   });
 
-
   document.addEventListener("wheel", (e) => {
     if(e.deltaX > 40) {
       carouselControlNext.click()
@@ -83,9 +82,14 @@
       carouselControlPrev.click()
     }
   })
+
+  window.addEventListener('load', (event) => {
+    if(screen.width <= 480) {
+      carouselControlNext.click()
+    }
+  });
 </script>
 
 <style>
   body { overscroll-behavior-x: none; }
 </style>
-


### PR DESCRIPTION
Fix added for phones- auto focus on document load so swiping works without first having to click.